### PR TITLE
truncate diff_info to prevert slack api error

### DIFF
--- a/helpers_git.py
+++ b/helpers_git.py
@@ -44,9 +44,9 @@ def generate_diff(base_branch, current_commit_id, repo_url=''):
     # Truncate too long messages to prevent Slack Api error msg_too_long https://api.slack.com/methods/chat.postMessage#errors
     # Message must be less than 3001 character
     # So number is more or less made up and needs further verification.
-    if len(diff_info) > 2000:
-        diff_info = diff_info[:2000]
-        diff_info += '\ntoo diff info - the rest was truncated. Use link below to see full diff\n```\n\n'
+    if len(diff_info) > 2400:
+        diff_info = diff_info[:2400]
+        diff_info += '\n\n diff info was truncated. Use link below to see full diff\n```\n\n'
     else:
         diff_info += '\n```\n\n'
 

--- a/helpers_git.py
+++ b/helpers_git.py
@@ -40,7 +40,15 @@ def generate_diff(base_branch, current_commit_id, repo_url=''):
     cmd = f'git log --pretty=format:"%h %<(27)%ai %<(20)%an  %s" --graph {diff}'
     diff_info = f'Change log for changes to approve:\n```\n{cmd}\n'
     diff_info += subprocess.getoutput(cmd)
-    diff_info += '\n```\n\n'
+
+    # Truncate too long messages to prevent Slack Api error msg_too_long https://api.slack.com/methods/chat.postMessage#errors
+    # Message must be less than 3001 character
+    # So number is more or less made up and needs further verification.
+    if len(diff_info) > 2000:
+        diff_info = diff_info[:2000]
+        diff_info += '\ntoo diff info - the rest was truncated. Use link below to see full diff\n```\n\n'
+    else:
+        diff_info += '\n```\n\n'
 
     if 'github' in repo_url or 'gitlab' in repo_url:
         diff_info += f'\nFull diff for changes to approve: {repo_url}/compare/{diff}\n\n'

--- a/main.py
+++ b/main.py
@@ -54,13 +54,6 @@ if __name__ == "__main__":
         details += helpers_git.generate_diff(branch, current_commit_id, repo_url)
     details += helpers_time.generate_time_based_message(production_branches, branches_to_promote, timezone)
 
-    # Truncate too long messages to prevent Slack Api error msg_too_long https://api.slack.com/methods/chat.postMessage#errors
-    # Message must be less than 3001 character
-    # So number is more or less made up and needs further verification.
-    if len(text_for_request) > 2900:
-        details = details[:2900]
-        details += '\ntoo long message - the rest was truncated. Use link above to see full diff'
-
     header_for_header = f'Approval request for job {build_job_name}'
 
     SocketModeHandler(app, os.environ["SLACK_APP_TOKEN"], trace_enabled=True).connect()


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/app/main.py", line 152, in <module>
    message_deploy = app.client.chat_postMessage(
  File "/usr/local/lib/python3.8/site-packages/slack_sdk/web/client.py", line 1939, in chat_postMessage
    return self.api_call("chat.postMessage", json=kwargs)
  File "/usr/local/lib/python3.8/site-packages/slack_sdk/web/base_client.py", line 145, in api_call
    return self._sync_send(api_url=api_url, req_args=req_args)
  File "/usr/local/lib/python3.8/site-packages/slack_sdk/web/base_client.py", line 181, in _sync_send
    return self._urllib_api_call(
  File "/usr/local/lib/python3.8/site-packages/slack_sdk/web/base_client.py", line 313, in _urllib_api_call
    return SlackResponse(
  File "/usr/local/lib/python3.8/site-packages/slack_sdk/web/slack_response.py", line 205, in validate
    raise e.SlackApiError(message=msg, response=self)
slack_sdk.errors.SlackApiError: The request to the Slack API failed. (url: https://www.slack.com/api/chat.postMessage)
Error: ver responded with: {'ok': False, 'error': 'invalid_blocks', 'errors': ['failed to match all allowed schemas [json-pointer:/blocks/3/text]', 'must be less than 3001 characters [json-pointer:/blocks/3/text/text]'], 'response_metadata': {'messages': ['[ERROR] failed to match all allowed schemas [json-pointer:/blocks/3/text]', '[ERROR] must be less than 3001 characters [json-pointer:/blocks/3/text/text]']}}
Error: Process completed with exit code 1.
```