### PR TITLE
Fix license copyright holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 FivexL
+Copyright (c) 2020 FivexL Consulting Services OÜ
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updates the LICENSE copyright holder to use the legal company name, FivexL Consulting Services OÜ.