### PR TITLE
Add optional TRIGGERED_BY_EMAIL to mention who triggered the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Configuration is done via env variables
 * `SLACK_BOT_TOKEN` - Slack bot token. Mandatory parameter. scopes: channels:history, chat:write, reactions:read, users:read.email, users:read
 * `SLACK_APP_TOKEN` - Slack app token. Mandatory parameter. scopes: connections:write
 * `SLACK_CHANNEL_NAME` - Slack channel name. Also channel_id can be used
+* `TRIGGERED_BY_EMAIL` - Email of the person who triggered the build, for example by pressing the merge button. Optional parameter. When set, a `Triggered by` line is added to the approval message, mentioning that person if the email matches a Slack profile. Useful because the commit itself does not always point at a person: squash merges on GitHub, for instance, are committed as `noreply@github.com`
 
 # Slack App manifect example 
 ```yaml

--- a/main.py
+++ b/main.py
@@ -26,6 +26,9 @@ if __name__ == "__main__":
     timezone = os.environ['TIMEZONE']
     production_branches = os.environ['PRODUCTION_BRANCHES'].split()
     slack_bot_token = os.environ["SLACK_BOT_TOKEN"]
+    # Not every commit is made by a person - squash merges, for instance, are committed by
+    # the SCM itself - so CI can tell us who triggered the build. Optional.
+    triggered_by_email = os.environ.get('TRIGGERED_BY_EMAIL', '')
 
     print(f'branches_to_promote: {branches_to_promote}')
     print(f'production_branches: {production_branches}')
@@ -40,6 +43,11 @@ if __name__ == "__main__":
     author_email = helpers_git.get_author_email_for_ref(current_commit_id)
     author_slack_id = helpers_slack.user_id_by_email(app, author_email)
     author_id = f'<@{author_slack_id}>' if author_slack_id is not None else author_email
+    triggered_by_id = None
+    if triggered_by_email:
+        triggered_by_slack_id = helpers_slack.user_id_by_email(app, triggered_by_email)
+        triggered_by_id = (f'<@{triggered_by_slack_id}>'
+                           if triggered_by_slack_id is not None else triggered_by_email)
     commit_msg = helpers_git.get_commit_message_for_ref(current_commit_id)
 
     text_for_request = 'If approved will promote commit(s) below to branch '
@@ -49,7 +57,10 @@ if __name__ == "__main__":
     details += f'Commit message: `{commit_msg}`\n'
     details += f'Commit id: `{current_commit_id}`\n'
     details += f'Committer: {commiter_id}\n'
-    details += f'Author: {author_id}\n\n'
+    details += f'Author: {author_id}\n'
+    if triggered_by_id is not None:
+        details += f'Triggered by: {triggered_by_id}\n'
+    details += '\n'
     details += helpers_time.generate_time_based_message(production_branches, branches_to_promote, timezone)
 
     # Generate separate diff blocks for every branch


### PR DESCRIPTION
## Problem

The approval message identifies two people: the commit's committer and its author. Neither is reliably a person.

On GitHub, every commit created by the platform itself — squash merges, merge commits, rebase merges, web-editor edits, API-created commits — is committed as `GitHub <noreply@github.com>`. On a protected branch that only ever receives merges through the merge button, that is *every* commit. Sampling ~200 commits on `main` across five of our repos, 185 had `noreply@github.com` as the committer; the handful that didn't were local pushes.

The author is whoever opened the pull request, which is often a bot (Dependabot, a code-review app). So an approval request can arrive with no human mentioned at all, even though a person just pressed Merge and is waiting on the deploy:

```
Commit message: `Update workflow file .github/workflows/ai-code-review.yml (#345)`
Committer: noreply@github.com
Author: 263481705+hippo-code-reviewer[bot]@users.noreply.github.com
```

That identity does exist — CI knows it (`github.triggering_actor` on GitHub Actions, `GITLAB_USER_EMAIL` on GitLab) — there's just no way to hand it to Magic Button.

## Change

A new optional `TRIGGERED_BY_EMAIL` variable. When set, a `Triggered by` line is added to the details block, resolving the email to a Slack mention and falling back to the plain email — the same treatment the committer and author lines already get. When unset, the message is byte-for-byte what it is today.

```
Committer: noreply@github.com
Author: 263481705+hippo-code-reviewer[bot]@users.noreply.github.com
Triggered by: <@U01ANDREI>
```

## Testing

- `flake8` and `pylint -E` clean, per `lint.sh`.
- Rendered the details block through `main.py` with Slack and git stubbed, across all three paths: email resolvable in Slack (mention), email unknown to Slack (plain-text fallback), and variable unset (unchanged output).