### PR TITLE
Add optional TRIGGERED_BY_EMAIL to mention who triggered the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Configuration is done via env variables
 * `SLACK_BOT_TOKEN` - Slack bot token. Mandatory parameter. scopes: channels:history, chat:write, reactions:read, users:read.email, users:read
 * `SLACK_APP_TOKEN` - Slack app token. Mandatory parameter. scopes: connections:write
 * `SLACK_CHANNEL_NAME` - Slack channel name. Also channel_id can be used
-* `TRIGGERED_BY_EMAIL` - Email of the person who triggered the build, for example by pressing the merge button. Optional parameter. When set, a `Triggered by` line is added to the approval message, mentioning that person if the email matches a Slack profile. Useful because the commit itself does not always point at a person: squash merges on GitHub, for instance, are committed as `noreply@github.com`
+* `TRIGGERED_BY_EMAIL` - Email of the person who triggered the build, for example by pressing the merge button. Optional parameter. When set, a `Triggered by` line is added to the approval message, mentioning that person if the email matches a Slack profile. Useful because the commit itself does not always point at a person: squash merges on GitHub, for instance, are committed as `noreply@github.com`. A GitHub-generated noreply address (bare `noreply@github.com` or the privacy-enabled `<id>+<username>@users.noreply.github.com` form) never resolves to a person, so the `Triggered by` line is omitted entirely rather than showing that address
 
 # Slack App manifect example 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ settings:
           BRANCHES_TO_PROMOTE: "${{ env.GIT_DESTINATION_BRANCH }}"
           TIMEOUT_MINUTES: 1
           REPOSITORY_URL: "${{ fromJson(steps.repo.outputs.result).html_url }}"
+          # Who clicked Merge - not always the commit author/committer (e.g. squash
+          # merges are committed by GitHub as noreply@github.com). Optional.
+          TRIGGERED_BY_EMAIL: "${{ github.event.pusher.email }}"
         run: >
           mkdir -p magic-button/reports && chmod 777 magic-button/reports
           && docker run --rm
@@ -102,7 +105,7 @@ settings:
           -e SLACK_BOT_TOKEN -e SLACK_APP_TOKEN -e BUILD_JOB_NAME -e BUILD_JOB_URL
           -e CURRENT_GIT_COMMIT="$(git rev-parse HEAD)" -e REPOSITORY_NAME="$(basename $(git rev-parse --show-toplevel))"
           -e REPOSITORY_URL -e BRANCHES_TO_PROMOTE -e TIMEOUT_MINUTES -e TIMEZONE="Europe/Oslo" 
-          -e PRODUCTION_BRANCHES -e SLACK_CHANNEL_NAME
+          -e PRODUCTION_BRANCHES -e SLACK_CHANNEL_NAME -e TRIGGERED_BY_EMAIL
           ghcr.io/fivexl/magic-button:${{ env.MAGIC_BUTTON_VERSION }}
           && ls -all magic-button/reports && cat magic-button/reports/report.json
         continue-on-error: true
@@ -124,7 +127,7 @@ settings:
             
           script:
               - |
-                mkdir -p magic-button/reports && chmod 777 magic-button/reports && docker run --rm -v "$(pwd)/.git":/app/.git -v "$(pwd)/magic-button/reports":/app/reports -e SLACK_BOT_TOKEN -e SLACK_APP_TOKEN -e BUILD_JOB_NAME -e BUILD_JOB_URL -e CURRENT_GIT_COMMIT="$(git rev-parse HEAD)" -e REPOSITORY_NAME="$(basename $(git rev-parse --show-toplevel))" -e REPOSITORY_URL -e BRANCHES_TO_PROMOTE -e TIMEOUT_MINUTES -e TIMEZONE="Europe/Oslo"  -e PRODUCTION_BRANCHES -e SLACK_CHANNEL_NAME ghcr.io/fivexl/magic-button:$MAGIC_BUTTON_VERSION && ls -all magic-button/reports && cat magic-button/reports/report.json
+                mkdir -p magic-button/reports && chmod 777 magic-button/reports && docker run --rm -v "$(pwd)/.git":/app/.git -v "$(pwd)/magic-button/reports":/app/reports -e SLACK_BOT_TOKEN -e SLACK_APP_TOKEN -e BUILD_JOB_NAME -e BUILD_JOB_URL -e CURRENT_GIT_COMMIT="$(git rev-parse HEAD)" -e REPOSITORY_NAME="$(basename $(git rev-parse --show-toplevel))" -e REPOSITORY_URL -e BRANCHES_TO_PROMOTE -e TIMEOUT_MINUTES -e TIMEZONE="Europe/Oslo"  -e PRODUCTION_BRANCHES -e SLACK_CHANNEL_NAME -e TRIGGERED_BY_EMAIL="$GITLAB_USER_EMAIL" ghcr.io/fivexl/magic-button:$MAGIC_BUTTON_VERSION && ls -all magic-button/reports && cat magic-button/reports/report.json
 
           after_script:
             - >

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Configuration is done via env variables
 * `SLACK_BOT_TOKEN` - Slack bot token. Mandatory parameter. scopes: channels:history, chat:write, reactions:read, users:read.email, users:read
 * `SLACK_APP_TOKEN` - Slack app token. Mandatory parameter. scopes: connections:write
 * `SLACK_CHANNEL_NAME` - Slack channel name. Also channel_id can be used
+* `TRIGGERED_BY_EMAIL` - Email of the person who triggered the build, for example by pressing the merge button. Optional parameter. When set, a `Triggered by` line is added to the approval message, mentioning that person if the email matches a Slack profile. Useful because the commit itself does not always point at a person: squash merges on GitHub, for instance, are committed as `noreply@github.com`
 
 # Slack App manifect example 
 ```yaml

--- a/helpers_git.py
+++ b/helpers_git.py
@@ -1,18 +1,6 @@
 import subprocess
 import helpers_slack
 
-# GitHub-generated addresses that never resolve to a real Slack profile:
-# noreply@github.com (bare merge/squash commits) and the privacy-enabled
-# form <id>+<username>@users.noreply.github.com (bots, and any user with
-# "Keep my email addresses private" turned on - this is common, not rare).
-NOREPLY_DOMAIN_SUFFIX = '@users.noreply.github.com'
-NOREPLY_BARE_ADDRESS = 'noreply@github.com'
-
-
-def is_noreply_email(email):
-    email = (email or '').strip().lower()
-    return email == NOREPLY_BARE_ADDRESS or email.endswith(NOREPLY_DOMAIN_SUFFIX)
-
 
 def resolve_git_ref_to_sha1(ref_name):
     print(f'Resolving {ref_name} to Git SHA1...')

--- a/helpers_git.py
+++ b/helpers_git.py
@@ -1,6 +1,18 @@
 import subprocess
 import helpers_slack
 
+# GitHub-generated addresses that never resolve to a real Slack profile:
+# noreply@github.com (bare merge/squash commits) and the privacy-enabled
+# form <id>+<username>@users.noreply.github.com (bots, and any user with
+# "Keep my email addresses private" turned on - this is common, not rare).
+NOREPLY_DOMAIN_SUFFIX = '@users.noreply.github.com'
+NOREPLY_BARE_ADDRESS = 'noreply@github.com'
+
+
+def is_noreply_email(email):
+    email = (email or '').strip().lower()
+    return email == NOREPLY_BARE_ADDRESS or email.endswith(NOREPLY_DOMAIN_SUFFIX)
+
 
 def resolve_git_ref_to_sha1(ref_name):
     print(f'Resolving {ref_name} to Git SHA1...')

--- a/helpers_slack.py
+++ b/helpers_slack.py
@@ -92,10 +92,12 @@ def user_id_by_email(app, email):
         result = app.client.users_lookupByEmail(email=email)
         return result['user']['id']
     except SlackApiError as err:
-        if err.response['error'] == 'users_not_found':
-            return None
-
-    return None
+        error_code = err.response['error']
+        if error_code == 'users_not_found':
+            print(f'No Slack user found for email {email}')
+        else:
+            print(f'Slack lookup failed for email {email}: {error_code}')
+        return None
 
 
 def is_message_longer_than_limit(message):

--- a/helpers_slack.py
+++ b/helpers_slack.py
@@ -11,6 +11,13 @@ from main import REPORT_FILE
 
 SLACK_MESSAGE_SIZE_LIMIT = 3001
 
+# GitHub-generated addresses that never resolve to a real Slack profile:
+# noreply@github.com (bare merge/squash commits) and the privacy-enabled
+# form <id>+<username>@users.noreply.github.com (bots, and any user with
+# "Keep my email addresses private" turned on - this is common, not rare).
+NOREPLY_DOMAIN_SUFFIX = '@users.noreply.github.com'
+NOREPLY_BARE_ADDRESS = 'noreply@github.com'
+
 
 def init_app(slack_bot_token, approve_action_id, cancel_action_id):
     app = App(token=slack_bot_token)
@@ -85,6 +92,11 @@ def gen_report(usernames, teams, channel, message, approval_code):
     }
     with open(REPORT_FILE, "w") as outfile:
         json.dump(report, outfile)
+
+
+def is_noreply_email(email):
+    email = (email or '').strip().lower()
+    return email == NOREPLY_BARE_ADDRESS or email.endswith(NOREPLY_DOMAIN_SUFFIX)
 
 
 def user_id_by_email(app, email):

--- a/main.py
+++ b/main.py
@@ -26,6 +26,9 @@ if __name__ == "__main__":
     timezone = os.environ['TIMEZONE']
     production_branches = os.environ['PRODUCTION_BRANCHES'].split()
     slack_bot_token = os.environ["SLACK_BOT_TOKEN"]
+    # Not every commit is made by a person - squash merges, for instance, are committed by
+    # the SCM itself - so CI can tell us who triggered the build. Optional.
+    triggered_by_email = os.environ.get('TRIGGERED_BY_EMAIL', '')
 
     print(f'branches_to_promote: {branches_to_promote}')
     print(f'production_branches: {production_branches}')
@@ -40,6 +43,11 @@ if __name__ == "__main__":
     author_email = helpers_git.get_author_email_for_ref(current_commit_id)
     author_slack_id = helpers_slack.user_id_by_email(app, author_email)
     author_id = f'<@{author_slack_id}>' if author_slack_id is not None else author_email
+    triggered_by_id = None
+    if triggered_by_email:
+        triggered_by_slack_id = helpers_slack.user_id_by_email(app, triggered_by_email)
+        triggered_by_id = (f'<@{triggered_by_slack_id}>'
+                           if triggered_by_slack_id is not None else triggered_by_email)
     commit_msg = helpers_git.get_commit_message_for_ref(current_commit_id)
 
     text_for_request = 'If approved will promote commit(s) below to branch '
@@ -49,7 +57,10 @@ if __name__ == "__main__":
     details += f'Commit message: `{commit_msg}`\n'
     details += f'Commit id: `{current_commit_id}`\n'
     details += f'Committer: {commiter_id}\n'
-    details += f'Author: {author_id}\n\n'
+    details += f'Author: {author_id}\n'
+    if triggered_by_id is not None:
+        details += f'Triggered by: {triggered_by_id}\n'
+    details += '\n'
     details += helpers_time.generate_time_based_message(production_branches, branches_to_promote, timezone)
 
     # Generate separate diff blocks for every branch

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
     slack_bot_token = os.environ["SLACK_BOT_TOKEN"]
     # Not every commit is made by a person - squash merges, for instance, are committed by
     # the SCM itself - so CI can tell us who triggered the build. Optional.
-    triggered_by_email = os.environ.get('TRIGGERED_BY_EMAIL', '')
+    triggered_by_email = os.environ.get('TRIGGERED_BY_EMAIL', '').strip()
 
     print(f'branches_to_promote: {branches_to_promote}')
     print(f'production_branches: {production_branches}')
@@ -44,9 +44,7 @@ if __name__ == "__main__":
     author_slack_id = helpers_slack.user_id_by_email(app, author_email)
     author_id = f'<@{author_slack_id}>' if author_slack_id is not None else author_email
     triggered_by_id = None
-    triggered_by_valid = (triggered_by_email and triggered_by_email.strip()
-                          and not helpers_git.is_noreply_email(triggered_by_email))
-    if triggered_by_valid:
+    if triggered_by_email and not helpers_slack.is_noreply_email(triggered_by_email):
         triggered_by_slack_id = helpers_slack.user_id_by_email(app, triggered_by_email)
         triggered_by_id = (f'<@{triggered_by_slack_id}>'
                            if triggered_by_slack_id is not None else triggered_by_email)

--- a/main.py
+++ b/main.py
@@ -44,7 +44,9 @@ if __name__ == "__main__":
     author_slack_id = helpers_slack.user_id_by_email(app, author_email)
     author_id = f'<@{author_slack_id}>' if author_slack_id is not None else author_email
     triggered_by_id = None
-    if triggered_by_email:
+    triggered_by_valid = (triggered_by_email and triggered_by_email.strip()
+                          and not helpers_git.is_noreply_email(triggered_by_email))
+    if triggered_by_valid:
         triggered_by_slack_id = helpers_slack.user_id_by_email(app, triggered_by_email)
         triggered_by_id = (f'<@{triggered_by_slack_id}>'
                            if triggered_by_slack_id is not None else triggered_by_email)


### PR DESCRIPTION
Same-repo mirror of #7 (fivexl/magic-button#7 from AndreiHippo:feat/triggered-by-email), opened so the AI code review workflow can run on it - fork PRs are excluded by design (see #8).

Original description from #7:

## Problem
The approval message identifies two people: the commits committer and its author. Neither is reliably a person. On GitHub, every commit created by the platform itself - squash merges, merge commits, rebase merges, web-editor edits, API-created commits - is committed as `GitHub <noreply@github.com>`. On a protected branch that only ever receives merges through the merge button, that is every commit. The author is whoever opened the pull request, which is often a bot (Dependabot, a code-review app). So an approval request can arrive with no human mentioned at all, even though a person just pressed Merge and is waiting on the deploy.

## Change
A new optional `TRIGGERED_BY_EMAIL` variable. When set, a `Triggered by` line is added to the details block, resolving the email to a Slack mention and falling back to the plain email - the same treatment the committer and author lines already get. When unset, the message is byte-for-byte what it is today.

## Testing
- `flake8` and `pylint -E` clean, per `lint.sh`.
- Rendered the details block through `main.py` with Slack and git stubbed, across all three paths: email resolvable in Slack (mention), email unknown to Slack (plain-text fallback), and variable unset (unchanged output).

---
Credit: AndreiHippo. Close #7 once this merges (or supersede it).