### PR TITLE
chore: bump Python base image, slack_bolt, pytz, and lint tooling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM python:3.12-alpine
 
 RUN apk add --no-cache --virtual .tmp-packeges build-base \
     && pip install dumb-init==1.2.5\

--- a/lint.sh
+++ b/lint.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-pip3 install flake8==4.0.1 pylint==2.12.2
+pip3 install flake8==7.1.1 pylint==3.3.1
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-slack_bolt == 1.9.0
-pytz==2021.1
+slack_bolt == 1.30.0
+pytz==2026.2


### PR DESCRIPTION
## Problem
`python:3.8-alpine` in the Dockerfile is on a Python version that reached upstream end-of-life on 2024-10-07 - it no longer receives security patches from CPython, ever. `requirements.txt` pins `slack_bolt==1.9.0` (4+ years behind current, misses a real security fix requiring signatures for ssl_check request verification) and `pytz==2021.1` (5-year-stale IANA timezone database). `lint.sh` pins `flake8==4.0.1`/`pylint==2.12.2`, which fail outright on any current Python: flake8 4.0.1 crashes on the modern `importlib.metadata` API, and pylint 2.12.2's `wrapt` dependency fails to build.

## Why it matters
An EOL Python base image is an unpatched attack surface with no upstream fix path. The stale `slack_bolt` misses an actual security-relevant fix. The stale `pytz` can produce wrong UTC offsets for any timezone whose rules changed since 2021, which directly affects `helpers_time.generate_time_based_message`'s promotion-window logic. The broken lint pins mean `lint.sh` cannot run at all once the CI/dev environment's Python moves forward - it currently only "works" because CI still runs the old 3.8 image.

## Fix (symptoms -> root cause -> change)
Symptom: stale, EOL, and partially-broken toolchain. Root cause: pins were never revisited since initial setup. Change: bump each pin to a current, compatible version, keeping the base Python and lint tooling in sync so `lint.sh` keeps working after the Dockerfile bump:
- `Dockerfile`: `python:3.8-alpine` -> `python:3.12-alpine`
- `requirements.txt`: `slack_bolt` `1.9.0` -> `1.30.0`, `pytz` `2021.1` -> `2026.2`
- `lint.sh`: `flake8` `4.0.1` -> `7.1.1`, `pylint` `2.12.2` -> `3.3.1`

No application code changed.

## Tests
No automated tests exist for this repo beyond `lint.sh` (see `test.sh`, which appears to be a manual/local harness requiring live Slack credentials).

## Manual verification
- `python3 -m py_compile` clean on all `.py` modules.
- `flake8==7.1.1` and `pylint==3.3.1` (the new pins) installed and ran cleanly against a current Python interpreter and this repo's code (0 findings from flake8 respecting `setup.cfg`'s `max-line-length=110`; pylint's only output was import-resolution noise from not having `slack_bolt`/`pytz` installed in that lint-only venv, not a real finding). The *old* pins (`flake8==4.0.1`, `pylint==2.12.2`) could not even run against a current Python in the same test - confirming the bump is necessary, not just cosmetic.
- Did **not** exercise a live `slack_bolt==1.30.0` install against this repo's actual Bolt usage (`App`, `SocketModeHandler(app, token).connect()`/`.close()`, `@app.action`, `app.client.chat_postMessage`/`chat_delete`/`chat_postEphemeral`/`users_lookupByEmail`, `SlackApiError`) - that surface has been stable across this version range per the Bolt-Python changelog, but this should be confirmed by CI or a real Slack run before merge, since no Slack credentials were available in this environment.

## Notes
- Chose 3.12 over the latest 3.14 deliberately: 3.14 is where the *old* lint pins failed in testing, and jumping straight to it risks a second wave of tooling incompatibilities in the same PR. 3.12 is current, well-supported, and comfortably clears `slack_bolt`'s Python 3.7+ floor.
- `dumb-init==1.2.5` in the Dockerfile was left as-is - it's a stable, rarely-updated process supervisor and nothing found suggests a newer version fixes anything relevant here.
